### PR TITLE
Fix wrong filename in testing branch

### DIFF
--- a/.sync/workflows/leaf/label-issues.yml
+++ b/.sync/workflows/leaf/label-issues.yml
@@ -31,4 +31,4 @@ on:
 
 jobs:
   apply:
-    uses: makubacki/mu_devops/.github/workflows/LabelSyncer.yml@add_file_sync_testing
+    uses: makubacki/mu_devops/.github/workflows/Labeler.yml@add_file_sync_testing


### PR DESCRIPTION
The wrong workflow filename was used whent he testing changes were created.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>