### PR TITLE
Condition PR labels on PR event

### DIFF
--- a/.github/workflows/Labeler.yml
+++ b/.github/workflows/Labeler.yml
@@ -39,6 +39,7 @@ jobs:
           configuration-path: .github/workflows/label-issues/file-paths.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+        if: github.event_name == 'pull_request'
 
       - name: Apply Labels Based on PR Messages
         uses: github/issue-labeler@v2.5
@@ -46,3 +47,4 @@ jobs:
           configuration-path: .github/workflows/label-issues/regex-pull-requests.yml
           enable-versioned-regex: 0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'pull_request'


### PR DESCRIPTION
Checks if the event is a PR for PR explicit labeling actions to avoid running on other events like issue triggers.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>