### PR TITLE
label-issues: Invert functional impact label logic

### DIFF
--- a/.sync/workflows/config/label-issues/regex-pull-requests.yml
+++ b/.sync/workflows/config/label-issues/regex-pull-requests.yml
@@ -12,7 +12,7 @@ impact:breaking-change:
   - '\s*-\s*\[\s*[x|X]\s*\] Breaking change\?'
 
 impact:non-functional:
-  - '\s*-\s*\[\s*[x|X]\s*\] Impacts functionality\?'
+  - '\s*-\s*\[\s*(?![x|X])\s*\] Impacts functionality\?'
 
 impact:security:
   - '\s*-\s*\[\s*[x|X]\s*\] Impacts security\?'


### PR DESCRIPTION
The checkbox exposed to contributors in a PR to determine whether the PR has a functional impact states:

"Impacts functionality?"

This uses positive logic to simplify understanding by the user.

Currently the `impact:non-functional` label is applied if the checkbox is checked.

This change inverts the logic to apply the label as expected.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>