### PR TITLE
Remove PR link from PR items in release notes

### DIFF
--- a/.github/ReleaseDraft.yml
+++ b/.github/ReleaseDraft.yml
@@ -51,7 +51,6 @@ change-template: >-
           <!-- Non-breaking space to have content if body is empty -->
           &nbsp; $BODY
         </blockquote>
-        Pull Request: $URL
         <hr>
       </details>
     </li>


### PR DESCRIPTION
Already has a PR link so not needed in this spot.